### PR TITLE
Latest conan packaging tool. This will bring in the correct Conan dependency

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -19,7 +19,6 @@ if [[ "$(uname -s)" == 'Darwin' ]]; then
     pyenv activate conan
 fi
 
-pip install conan --upgrade
-pip install conan_package_tools==0.30.2
+pip install conan_package_tools --upgrade
 
 conan user


### PR DESCRIPTION
We want Conan Packaging Tools to install Conan as a dependency because this ensures that it selects the correct and compatible version of Conan to run side-by-side.