### PR TITLE
Fix build after catch2 default-branch name-change

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,10 +44,12 @@ target_compile_features(indirect_value
 add_library(indirect_value::indirect_value ALIAS indirect_value)
 
 if (${CPP_INDIRECT_IS_SUBPROJECT})
+
     if (${BUILD_TESTING})
         FetchContent_Declare(
             catch2
             GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+            GIT_TAG v2.x
         )
 
         FetchContent_GetProperties(catch2)


### PR DESCRIPTION
Use v2.x branch for catch2 as master branch no longer exists