### PR TITLE
Add relational operators to indirect_value

### DIFF
--- a/indirect_value.h
+++ b/indirect_value.h
@@ -5,6 +5,10 @@
 #include <type_traits>
 #include <utility>
 
+#if defined(__cpp_lib_three_way_comparison) && defined(__cpp_lib_concepts)
+#include <compare>
+#endif
+
 #ifdef __cpp_concepts
 #define ISOCPP_P1950_REQUIRES(x) requires x
 #else
@@ -113,6 +117,250 @@ class indirect_value : private indirect_value_base<T, C> {
 
 template <class T>
 indirect_value(T*) -> indirect_value<T>;
+
+// Relational operators between two indirect_values.
+template <class T1, class C1, class D1, class T2, class C2, class D2>
+bool operator==(const indirect_value<T1, C1, D1>& lhs,
+                const indirect_value<T2, C2, D2>& rhs) {
+  const bool leftHasValue = bool(lhs);
+  return leftHasValue == bool(rhs) && (!leftHasValue || *lhs == *rhs);
+}
+
+template <class T1, class C1, class D1, class T2, class C2, class D2>
+bool operator!=(const indirect_value<T1, C1, D1>& lhs,
+                const indirect_value<T2, C2, D2>& rhs) {
+  const bool leftHasValue = bool(lhs);
+  return leftHasValue != bool(rhs) || (leftHasValue && *lhs != *rhs);
+}
+
+template <class T1, class C1, class D1, class T2, class C2, class D2>
+bool operator<(const indirect_value<T1, C1, D1>& lhs,
+               const indirect_value<T2, C2, D2>& rhs) {
+  return bool(rhs) && (!bool(lhs) || *lhs < *rhs);
+}
+
+template <class T1, class C1, class D1, class T2, class C2, class D2>
+bool operator>(const indirect_value<T1, C1, D1>& lhs,
+               const indirect_value<T2, C2, D2>& rhs) {
+  return bool(lhs) && (!bool(rhs) || *lhs > *rhs);
+}
+
+template <class T1, class C1, class D1, class T2, class C2, class D2>
+bool operator<=(const indirect_value<T1, C1, D1>& lhs,
+                const indirect_value<T2, C2, D2>& rhs) {
+  return !bool(lhs) || (bool(rhs) && *lhs <= *rhs);
+}
+
+template <class T1, class C1, class D1, class T2, class C2, class D2>
+bool operator>=(const indirect_value<T1, C1, D1>& lhs,
+                const indirect_value<T2, C2, D2>& rhs) {
+  return !bool(rhs) || (bool(lhs) && *lhs >= *rhs);
+}
+
+#if defined(__cpp_lib_three_way_comparison) && defined(__cpp_lib_concepts)
+template <class T1, class C1, class D1, std::three_way_comparable_with<T1> T2,
+          class C2, class D2>
+std::compare_three_way_result_t<T1, T2> operator<=>(
+    const indirect_value<T1, C1, D1>& lhs,
+    const indirect_value<T2, C2, D2>& rhs) {
+  if (lhs && rhs) {
+    return *lhs <=> *rhs;
+  }
+  return bool(lhs) <=> bool(rhs);
+}
+#endif
+
+// Comparisons with nullptr_t.
+template <class T, class C, class D>
+bool operator==(const indirect_value<T, C, D>& lhs, std::nullptr_t) noexcept {
+  return !lhs;
+}
+
+#if defined(__cpp_lib_three_way_comparison) && defined(__cpp_lib_concepts)
+template <class T, class C, class D>
+std::strong_ordering operator<=>(const indirect_value<T, C, D>& lhs,
+                                 std::nullptr_t) {
+  return bool(lhs) <=> false;
+}
+#else
+template <class T, class C, class D>
+bool operator==(std::nullptr_t, const indirect_value<T, C, D>& rhs) noexcept {
+  return !rhs;
+}
+
+template <class T, class C, class D>
+bool operator!=(const indirect_value<T, C, D>& lhs, std::nullptr_t) noexcept {
+  return bool(lhs);
+}
+
+template <class T, class C, class D>
+bool operator!=(std::nullptr_t, const indirect_value<T, C, D>& rhs) noexcept {
+  return bool(rhs);
+}
+
+template <class T, class C, class D>
+bool operator<(const indirect_value<T, C, D>&, std::nullptr_t) noexcept {
+  return false;
+}
+
+template <class T, class C, class D>
+bool operator<(std::nullptr_t, const indirect_value<T, C, D>& rhs) noexcept {
+  return bool(rhs);
+}
+
+template <class T, class C, class D>
+bool operator>(const indirect_value<T, C, D>& lhs, std::nullptr_t) noexcept {
+  return bool(lhs);
+}
+
+template <class T, class C, class D>
+bool operator>(std::nullptr_t, const indirect_value<T, C, D>&) noexcept {
+  return false;
+}
+
+template <class T, class C, class D>
+bool operator<=(const indirect_value<T, C, D>& lhs, std::nullptr_t) noexcept {
+  return !lhs;
+}
+
+template <class T, class C, class D>
+bool operator<=(std::nullptr_t, const indirect_value<T, C, D>&) noexcept {
+  return true;
+}
+
+template <class T, class C, class D>
+bool operator>=(const indirect_value<T, C, D>&, std::nullptr_t) noexcept {
+  return true;
+}
+
+template <class T, class C, class D>
+bool operator>=(std::nullptr_t, const indirect_value<T, C, D>& rhs) noexcept {
+  return !rhs;
+}
+#endif
+
+// Comparisons with T
+template <class T>
+using _enable_if_convertible_to_bool =
+    std::enable_if_t<std::is_convertible_v<T, bool>, bool>;
+
+template <class LHS, class RHS>
+using _enable_if_comparable_with_equal =
+    _enable_if_convertible_to_bool<decltype(std::declval<const LHS&>() ==
+                                            std::declval<const RHS&>())>;
+
+template <class LHS, class RHS>
+using _enable_if_comparable_with_not_equal =
+    _enable_if_convertible_to_bool<decltype(std::declval<const LHS&>() !=
+                                            std::declval<const RHS&>())>;
+
+template <class LHS, class RHS>
+using _enable_if_comparable_with_less =
+    _enable_if_convertible_to_bool<decltype(std::declval<const LHS&>() <
+                                            std::declval<const RHS&>())>;
+
+template <class LHS, class RHS>
+using _enable_if_comparable_with_greater =
+    _enable_if_convertible_to_bool<decltype(std::declval<const LHS&>() >
+                                            std::declval<const RHS&>())>;
+
+template <class LHS, class RHS>
+using _enable_if_comparable_with_less_equal =
+    _enable_if_convertible_to_bool<decltype(std::declval<const LHS&>() <=
+                                            std::declval<const RHS&>())>;
+
+template <class LHS, class RHS>
+using _enable_if_comparable_with_greater_equal =
+    _enable_if_convertible_to_bool<decltype(std::declval<const LHS&>() >=
+                                            std::declval<const RHS&>())>;
+
+template <class T, class C, class D, class U>
+auto operator==(const indirect_value<T, C, D>& lhs, const U& rhs)
+    -> _enable_if_comparable_with_equal<T, U> {
+  return lhs && *lhs == rhs;
+}
+
+template <class T, class C, class D, class U>
+auto operator==(const T& lhs, const indirect_value<U, C, D>& rhs)
+    -> _enable_if_comparable_with_equal<T, U> {
+  return rhs && lhs == *rhs;
+}
+
+template <class T, class C, class D, class U>
+auto operator!=(const indirect_value<T, C, D>& lhs, const U& rhs)
+    -> _enable_if_comparable_with_not_equal<T, U> {
+  return !lhs || *lhs != rhs;
+}
+
+template <class T, class C, class D, class U>
+auto operator!=(const T& lhs, const indirect_value<U, C, D>& rhs)
+    -> _enable_if_comparable_with_not_equal<T, U> {
+  return !rhs || lhs != *rhs;
+}
+
+template <class T, class C, class D, class U>
+auto operator<(const indirect_value<T, C, D>& lhs, const U& rhs)
+    -> _enable_if_comparable_with_less<T, U> {
+  return !lhs || *lhs < rhs;
+}
+
+template <class T, class C, class D, class U>
+auto operator<(const T& lhs, const indirect_value<U, C, D>& rhs)
+    -> _enable_if_comparable_with_less<T, U> {
+  return rhs && lhs < *rhs;
+}
+
+template <class T, class C, class D, class U>
+auto operator>(const indirect_value<T, C, D>& lhs, const U& rhs)
+    -> _enable_if_comparable_with_greater<T, U> {
+  return lhs && *lhs > rhs;
+}
+
+template <class T, class C, class D, class U>
+auto operator>(const T& lhs, const indirect_value<U, C, D>& rhs)
+    -> _enable_if_comparable_with_greater<T, U> {
+  return !rhs || lhs > *rhs;
+}
+
+template <class T, class C, class D, class U>
+auto operator<=(const indirect_value<T, C, D>& lhs, const U& rhs)
+    -> _enable_if_comparable_with_less_equal<T, U> {
+  return !lhs || *lhs <= rhs;
+}
+
+template <class T, class C, class D, class U>
+auto operator<=(const T& lhs, const indirect_value<U, C, D>& rhs)
+    -> _enable_if_comparable_with_less_equal<T, U> {
+  return rhs && lhs <= *rhs;
+}
+
+template <class T, class C, class D, class U>
+auto operator>=(const indirect_value<T, C, D>& lhs, const U& rhs)
+    -> _enable_if_comparable_with_greater_equal<T, U> {
+  return lhs && *lhs >= rhs;
+}
+
+template <class T, class C, class D, class U>
+auto operator>=(const T& lhs, const indirect_value<U, C, D>& rhs)
+    -> _enable_if_comparable_with_greater_equal<T, U> {
+  return !rhs || lhs >= *rhs;
+}
+
+#if defined(__cpp_lib_three_way_comparison) && defined(__cpp_lib_concepts)
+
+template <class>
+inline constexpr bool _is_indirect_value_v = false;
+
+template <class T, class C, class D>
+inline constexpr bool _is_indirect_value_v<indirect_value<T, C, D>> = true;
+
+template <class T, class C, class D, class U>
+requires (!_is_indirect_value_v<U>) &&
+    std::three_way_comparable_with<T, U> std::compare_three_way_result_t<T, U>
+    operator<=>(const indirect_value<T, C, D>& lhs, const U& rhs) {
+  return bool(lhs) ? *lhs <=> rhs : std::strong_ordering::less;
+}
+#endif
 
 }  // namespace isocpp_p1950
 

--- a/test_indirect_value.cpp
+++ b/test_indirect_value.cpp
@@ -345,3 +345,309 @@ TEST_CASE("Swap overload for indirect_value", "[swap.primitive]") {
     }
   }
 }
+
+TEST_CASE("Relational operators between two indirect_values", "[TODO]") {
+  GIVEN("Two empty indirect_value values") {
+    const indirect_value<int> a;
+    const indirect_value<int> b;
+
+    THEN("The values should be equal") {
+      REQUIRE(a == b);
+      REQUIRE(!(a != b));
+      REQUIRE(!(a < b));
+      REQUIRE(!(a > b));
+      REQUIRE(a <= b);
+      REQUIRE(a >= b);
+    }
+  }
+
+  GIVEN("One non-empty and one empty indirect_value") {
+    const indirect_value<int> nonEmpty(std::in_place, 0);
+    const indirect_value<int> empty;
+
+    THEN("The values should be unequal") {
+      REQUIRE(!(nonEmpty == empty));
+      REQUIRE(nonEmpty != empty);
+      REQUIRE(!(nonEmpty < empty));
+      REQUIRE(nonEmpty > empty);
+      REQUIRE(!(nonEmpty <= empty));
+      REQUIRE(nonEmpty >= empty);
+    }
+  }
+
+  GIVEN("Two non-empty indirect_value values with equal values") {
+    const indirect_value<int> a(std::in_place, 0);
+    const indirect_value<int> b(std::in_place, 0);
+    THEN("The values should be equal") {
+      REQUIRE(a == b);
+      REQUIRE(!(a != b));
+      REQUIRE(!(a < b));
+      REQUIRE(!(a > b));
+      REQUIRE(a <= b);
+      REQUIRE(a >= b);
+    }
+  }
+
+  GIVEN("Two non-empty indirect_value values with different values") {
+    const indirect_value<int> a(std::in_place, 0);
+    const indirect_value<int> b(std::in_place, 1);
+    THEN("a should be less than b") {
+      REQUIRE(!(a == b));
+      REQUIRE(a != b);
+      REQUIRE(a < b);
+      REQUIRE(!(a > b));
+      REQUIRE(a <= b);
+      REQUIRE(!(a >= b));
+    }
+  }
+}
+
+TEST_CASE("Relational operators between two indirect_values of different type",
+          "[TODO]") {
+  GIVEN("Two empty indirect_value values") {
+    const indirect_value<int> a;
+    const indirect_value<short> b;
+
+    THEN("The values should be equal") {
+      REQUIRE(a == b);
+      REQUIRE(!(a != b));
+      REQUIRE(!(a < b));
+      REQUIRE(!(a > b));
+      REQUIRE(a <= b);
+      REQUIRE(a >= b);
+    }
+  }
+
+  GIVEN("One non-empty and one empty indirect_value") {
+    const indirect_value<int> nonEmpty(std::in_place, 0);
+    const indirect_value<short> empty;
+
+    THEN("The values should be unequal") {
+      REQUIRE(!(nonEmpty == empty));
+      REQUIRE(nonEmpty != empty);
+      REQUIRE(!(nonEmpty < empty));
+      REQUIRE(nonEmpty > empty);
+      REQUIRE(!(nonEmpty <= empty));
+      REQUIRE(nonEmpty >= empty);
+    }
+  }
+
+  GIVEN("Two non-empty indirect_value values with equal values") {
+    const indirect_value<int> a(std::in_place, 0);
+    const indirect_value<short> b(std::in_place, short{0});
+    THEN("The values should be equal") {
+      REQUIRE(a == b);
+      REQUIRE(!(a != b));
+      REQUIRE(!(a < b));
+      REQUIRE(!(a > b));
+      REQUIRE(a <= b);
+      REQUIRE(a >= b);
+    }
+  }
+
+  GIVEN("Two non-empty indirect_value values with different values") {
+    const indirect_value<int> a(std::in_place, 0);
+    const indirect_value<short> b(std::in_place, short{1});
+    THEN("a should be less than b") {
+      REQUIRE(!(a == b));
+      REQUIRE(a != b);
+      REQUIRE(a < b);
+      REQUIRE(!(a > b));
+      REQUIRE(a <= b);
+      REQUIRE(!(a >= b));
+    }
+  }
+}
+
+TEST_CASE("Relational operators between an indirect_value and nullptr",
+          "[TODO]") {
+  GIVEN("An empty indirect_value") {
+    const indirect_value<int> empty;
+
+    THEN("The value should be equal to nullptr") {
+      REQUIRE(empty == nullptr);
+      REQUIRE(nullptr == empty);
+      REQUIRE(!(empty != nullptr));
+      REQUIRE(!(nullptr != empty));
+      REQUIRE(!(empty < nullptr));
+      REQUIRE(!(nullptr < empty));
+      REQUIRE(!(empty > nullptr));
+      REQUIRE(!(nullptr > empty));
+      REQUIRE(empty <= nullptr);
+      REQUIRE(nullptr <= empty);
+      REQUIRE(empty >= nullptr);
+      REQUIRE(nullptr >= empty);
+    }
+  }
+
+  GIVEN("A non-empty indirect_value") {
+    const indirect_value<int> nonEmpty(std::in_place);
+
+    THEN("The value should be unequal to nullptr") {
+      REQUIRE(!(nonEmpty == nullptr));
+      REQUIRE(!(nullptr == nonEmpty));
+      REQUIRE(nonEmpty != nullptr);
+      REQUIRE(nullptr != nonEmpty);
+      REQUIRE(!(nonEmpty < nullptr));
+      REQUIRE(nullptr < nonEmpty);
+      REQUIRE(nonEmpty > nullptr);
+      REQUIRE(!(nullptr > nonEmpty));
+      REQUIRE(!(nonEmpty <= nullptr));
+      REQUIRE(nullptr <= nonEmpty);
+      REQUIRE(nonEmpty >= nullptr);
+      REQUIRE(!(nullptr >= nonEmpty));
+    }
+  }
+}
+
+TEST_CASE("Relational operators between indirect_value and value_type",
+          "[TODO]") {
+  GIVEN("An empty indirect_value and a value_type") {
+    const indirect_value<int> empty;
+    const int value{};
+
+    THEN("The value should be greater") {
+      REQUIRE(!(empty == value));
+      REQUIRE(!(value == empty));
+      REQUIRE(empty != value);
+      REQUIRE(value != empty);
+      REQUIRE(empty < value);
+      REQUIRE(!(value < empty));
+      REQUIRE(!(empty > value));
+      REQUIRE(value > empty);
+      REQUIRE(empty <= value);
+      REQUIRE(!(value <= empty));
+      REQUIRE(!(empty >= value));
+      REQUIRE(value >= empty);
+    }
+  }
+
+  GIVEN("A non-empty indirect_value and a value_type with equal value") {
+    const indirect_value<int> nonEmpty(std::in_place, 0);
+    const int value{};
+
+    THEN("The value should be equal") {
+      REQUIRE(nonEmpty == value);
+      REQUIRE(value == nonEmpty);
+      REQUIRE(!(nonEmpty != value));
+      REQUIRE(!(value != nonEmpty));
+      REQUIRE(!(nonEmpty < value));
+      REQUIRE(!(value < nonEmpty));
+      REQUIRE(!(nonEmpty > value));
+      REQUIRE(!(value > nonEmpty));
+      REQUIRE(nonEmpty <= value);
+      REQUIRE(value <= nonEmpty);
+      REQUIRE(nonEmpty >= value);
+      REQUIRE(value >= nonEmpty);
+    }
+  }
+
+  GIVEN("A non-empty indirect_value and a value_type with smaller value") {
+    const indirect_value<int> nonEmpty(std::in_place, 0);
+    const int value{-1};
+
+    THEN("The value should be smaller") {
+      REQUIRE(!(nonEmpty == value));
+      REQUIRE(!(value == nonEmpty));
+      REQUIRE(nonEmpty != value);
+      REQUIRE(value != nonEmpty);
+      REQUIRE(!(nonEmpty < value));
+      REQUIRE(value < nonEmpty);
+      REQUIRE(nonEmpty > value);
+      REQUIRE(!(value > nonEmpty));
+      REQUIRE(!(nonEmpty <= value));
+      REQUIRE(value <= nonEmpty);
+      REQUIRE(nonEmpty >= value);
+      REQUIRE(!(value >= nonEmpty));
+    }
+  }
+}
+
+TEST_CASE(
+    "Relational operators between indirect_value and value_type of different "
+    "type",
+    "[TODO]") {
+  GIVEN("An empty indirect_value and a value_type") {
+    const indirect_value<int> empty;
+    const short value{};
+
+    THEN("The value should be greater") {
+      REQUIRE(!(empty == value));
+      REQUIRE(!(value == empty));
+      REQUIRE(empty != value);
+      REQUIRE(value != empty);
+      REQUIRE(empty < value);
+      REQUIRE(!(value < empty));
+      REQUIRE(!(empty > value));
+      REQUIRE(value > empty);
+      REQUIRE(empty <= value);
+      REQUIRE(!(value <= empty));
+      REQUIRE(!(empty >= value));
+      REQUIRE(value >= empty);
+    }
+  }
+
+  GIVEN("A non-empty indirect_value and a value_type with equal value") {
+    const indirect_value<int> nonEmpty(std::in_place, 0);
+    const short value{};
+
+    THEN("The value should be equal") {
+      REQUIRE(nonEmpty == value);
+      REQUIRE(value == nonEmpty);
+      REQUIRE(!(nonEmpty != value));
+      REQUIRE(!(value != nonEmpty));
+      REQUIRE(!(nonEmpty < value));
+      REQUIRE(!(value < nonEmpty));
+      REQUIRE(!(nonEmpty > value));
+      REQUIRE(!(value > nonEmpty));
+      REQUIRE(nonEmpty <= value);
+      REQUIRE(value <= nonEmpty);
+      REQUIRE(nonEmpty >= value);
+      REQUIRE(value >= nonEmpty);
+    }
+  }
+
+  GIVEN("A non-empty indirect_value and a value_type with smaller value") {
+    const indirect_value<int> nonEmpty(std::in_place, 0);
+    const short value{-1};
+
+    THEN("The value should be smaller") {
+      REQUIRE(!(nonEmpty == value));
+      REQUIRE(!(value == nonEmpty));
+      REQUIRE(nonEmpty != value);
+      REQUIRE(value != nonEmpty);
+      REQUIRE(!(nonEmpty < value));
+      REQUIRE(value < nonEmpty);
+      REQUIRE(nonEmpty > value);
+      REQUIRE(!(value > nonEmpty));
+      REQUIRE(!(nonEmpty <= value));
+      REQUIRE(value <= nonEmpty);
+      REQUIRE(nonEmpty >= value);
+      REQUIRE(!(value >= nonEmpty));
+    }
+  }
+}
+
+#ifdef __cpp_concepts
+
+template <class T, class U, class Comp>
+concept Compare = requires(const T& a, const U& b) {
+  { Comp{}(a, b) };
+  { Comp{}(b, a) };
+};
+
+TEST_CASE(
+    "Relational operators between indirect_value and value_type of "
+    "non-equality-comparable type",
+    "[TODO]") {
+  struct NonComparable {};
+  using IV = indirect_value<NonComparable>;
+  static_assert(!Compare<IV, NonComparable, std::equal_to<>>);
+  static_assert(!Compare<IV, NonComparable, std::not_equal_to<>>);
+  static_assert(!Compare<IV, NonComparable, std::less<>>);
+  static_assert(!Compare<IV, NonComparable, std::greater<>>);
+  static_assert(!Compare<IV, NonComparable, std::less_equal<>>);
+  static_assert(!Compare<IV, NonComparable, std::greater_equal<>>);
+}
+
+#endif


### PR DESCRIPTION
I've added relational operators to `indirect_value`. I followed the style of `std::optional`.
I did not touch the proposal, which therefore at the current moment doesn't mention relational operators at all.

