### PR TITLE
Add flags to test binary for coverage builds

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -2,9 +2,9 @@ name: Code Coverage
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
@@ -19,40 +19,38 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Install Lcov
-      shell: bash
-      run: |
+      - name: Install Lcov
+        shell: bash
+        run: |
           sudo apt update -y
           sudo apt-get install -y lcov
-  
-    - name: Configure CMake
-      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
-      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DENABLE_CODE_COVERAGE=1
 
-    - name: Build
-      # Build your program with the given configuration
-      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+      - name: Configure CMake
+        # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+        # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DENABLE_CODE_COVERAGE=1
 
-    - name: Test
-      working-directory: ${{github.workspace}}/build
-      # Execute tests defined by the CMake configuration.  
-      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: ctest -C ${{env.BUILD_TYPE}}
-      
-    - name: Gcov
-      # Run GCov target to collect coverage information.  
-      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} --target gcov
-      
-    - name: Lcov
-      # Run LCov target to generate code coverage report
-      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} --target lcov
+      - name: Build
+        # Build your program with the given configuration
+        run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
 
-    - name: Upload
-      working-directory: ${{github.workspace}}/build
-      # Run LCov target to generate code coverage report
-      run: bash <(curl -s https://codecov.io/bash) -X gcov || echo "Codecov did not collect coverage reports"
+      - name: Test
+        working-directory: ${{github.workspace}}/build
+        # Execute tests defined by the CMake configuration.
+        # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+        run: ctest -C ${{env.BUILD_TYPE}}
 
-   
+      - name: Gcov
+        # Run GCov target to collect coverage information.
+        run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} --target gcov
+
+      - name: Lcov
+        # Run LCov target to generate code coverage report
+        run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} --target lcov
+
+      - name: Upload
+        working-directory: ${{github.workspace}}/build
+        # Run LCov target to generate code coverage report
+        run: bash <(curl -s https://codecov.io/bash) -X gcov || echo "Codecov did not collect coverage reports"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,6 +130,8 @@ if (${CPP_INDIRECT_IS_SUBPROJECT})
         catch_discover_tests(test_indirect_value)
 
         if (ENABLE_CODE_COVERAGE)
+            target_compile_options(test_indirect_value 
+                PRIVATE "-g -O0 --coverage -fprofile-arcs -ftest-coverage")
             FetchContent_Declare(
                 codecoverage
                 GIT_REPOSITORY https://github.com/RWTH-HPC/CMake-codecov.git


### PR DESCRIPTION
This should avoid functions being optimised away and not reflected in coverage stats.