### PR TITLE
Replace unique_ptr by manual resource management. Add more unit tests.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,7 @@ if (${CPP_INDIRECT_IS_SUBPROJECT})
             PRIVATE
                 $<$<CXX_COMPILER_ID:MSVC>:/EHsc>
                 $<$<CXX_COMPILER_ID:MSVC>:/W4>
-                #$<$<CXX_COMPILER_ID:MSVC>:/bigobj>
+                $<$<CXX_COMPILER_ID:MSVC>:/bigobj>
                 $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:Clang>>:-Werror;-Wall;-Wno-self-assign-overloaded;-Wno-unknown-warning-option>
         )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,7 @@ if (${CPP_INDIRECT_IS_SUBPROJECT})
             PRIVATE
                 $<$<CXX_COMPILER_ID:MSVC>:/EHsc>
                 $<$<CXX_COMPILER_ID:MSVC>:/W4>
+                #$<$<CXX_COMPILER_ID:MSVC>:/bigobj>
                 $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:Clang>>:-Werror;-Wall;-Wno-self-assign-overloaded;-Wno-unknown-warning-option>
         )
 


### PR DESCRIPTION
Resolves #73.

As mentioned in #73, I had to remove the requires-expression from the copy constructor. It turned out that I also had to remove the requires-expression from the copy-assignment operator. Otherwise it would not be possible to call `swap(a, b)` for two indirect_values with an incomplete value_type. But now, the requirements of the "Completeness"-Table from the proposal are met.

I also added a few more unit tests for:
- Ensuring that the special member functions and callable-operator of the copier_type and deleter_type get invoked as expected
- Self-assigning
- Kind of "Strong exception guarantee" for the copy-assignment operator: When copying the value_type throws, `ptr_` remains unchanged. But when assigning the copier_type or deleter_type throws, then `ptr_` will be null.
- In the copy-assignment operator and copy constructor, use the deleter of the other indirect_value
- Tests for incompelte type

Sorry that this is such a bulky pull request.
Looking forward to your opinion.