### PR TITLE
Fix name of export set in cmake file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,14 +167,14 @@ if (${CPP_INDIRECT_IS_SUBPROJECT})
 
     install(
         TARGETS indirect_value
-        EXPORT indirect_value-target
+        EXPORT indirect_value-export-set
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     )
 
     install(
-        EXPORT indirect_value-target
+        EXPORT indirect_value-export-set
         NAMESPACE indirect_value::
         DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/indirect_value"
     )


### PR DESCRIPTION
In cmake parlance, this is an "export set" which may refer to multiple
targets.  The word target is already very overloaded in cmake, so best
not to introduce another overloaded meaning.