### PR TITLE
Introduce copier_traits

### DIFF
--- a/documentation/p1950.md
+++ b/documentation/p1950.md
@@ -477,11 +477,26 @@ This proposal is a pure library extension. It requires additions to be made to t
 
 # Technical specifications
 
-## X.X Class template `default_copy` [default.copy]
+## X.X Class template `copier_traits` [copier.traits]
+```
+namespace std {
+    template <class T>
+    struct copier_traits {
+        using deleter_type = *see below*;
+    };
+}
+```
+<code>using deleter_type = *see below*;</code>
+* Type: <code>T::deleter_type</code> if the *qualified-id* <code>T::deleter_type</code> is valid and denotes a type;
+    otherwise, <code>void (\*)(U\*)</code> if <code>T</code> is of the form <code>U\* (\*)(V)</code> for types <code>U</code> and <code>V</code>;
+    otherwise, there is no member <code>deleter_type</code>.
+
+## X.Y Class template `default_copy` [default.copy]
 ```
 namespace std {
     template <class T>
     struct default_copy {
+        using deleter_type = default_delete<T>;
         T* operator()(const T& t) const;
     };
 } // namespace std
@@ -492,8 +507,8 @@ The template parameter <code>T</code> of <code>default_copy</code> may be an inc
 <code>T* operator()(const T& t) const;</code>
 * Returns: <code>new T(t);</code>
 
-## X.Y Class template `indirect_value` [indirect_value]
-### X.Y.1 Class template `indirect_value` general [indirect_value.general]
+## X.Z Class template `indirect_value` [indirect_value]
+### X.Z.1 Class template `indirect_value` general [indirect_value.general]
 An `indirect_value` is an object that owns another object and manages that other object through a pointer. More precisely, an indirect value is an object `v` that stores a pointer to a second object `p` and will dispose of `p` when `v` is itself destroyed (e.g., when leaving block scope (9.7)). In this context, `v` is said to own `p`.
 
 An `indirect_value` object is empty if it does not own a pointer.
@@ -510,10 +525,10 @@ The template parameter `T` of `indirect_value` may be an incomplete type.
 
 *[Note: Implementations are encouraged to avoid the use of dynamic memory for ownership of small objects.]*
 
-### X.Y.2 Class template `indirect_value` synopsis [indirect_value.synopsis]
+### X.Z.2 Class template `indirect_value` synopsis [indirect_value.synopsis]
 
 ```
-    template <class T, class C = std::default_copy<T>, class D = std::default_delete<T>>
+    template <class T, class C = std::default_copy<T>, class D = typename std::copier_traits<C>::deleter_type>
     class indirect_value {
     public:
         using value_type = T;
@@ -558,7 +573,7 @@ The template parameter `T` of `indirect_value` may be an incomplete type.
 
 ```
 
-### X.Y.3 Class template `indirect_value` constructors [indirect_value.ctor]
+### X.Z.3 Class template `indirect_value` constructors [indirect_value.ctor]
 
 <code>constexpr indirect_value() noexcept;</code>
 * Remarks: The method shall work with incomplete pointer type for `T`.
@@ -567,7 +582,7 @@ The template parameter `T` of `indirect_value` may be an incomplete type.
 
 <code>explicit indirect_value(T* p, C c=C{}, D d=D{});</code>
 * Effects: Creates an `indirect_value` object that owns the pointer `p`. If `p` is non-null then the copier and deleter of the `indirect_value` constructed are moved from `c` and `d`.
-* Requires: `C` and `D` satisfy the requirements of CopyConstructible. If `p` is non-null then the expression `c(*p)` returns an object of type `T*`. The expression `d(p)` is well-formed, has well-defined behaviour, and does not throw exceptions.
+* Requires: `C` and `D` satisfy the requirements of CopyConstructible. If the arguments `c` and/or `d` are not supplied, then `C` and/or `D` respectively are default constructible types that are not pointer types. If `p` is non-null then the expression `c(*p)` returns an object of type `T*`. The expression `d(p)` is well-formed, has well-defined behaviour, and does not throw exceptions.
 * Postconditions: `bool(*this) == bool(p)`.
 * Remarks: A custom copier and deleter are said to be ‘present’ in a `indirect_value` initialised with this constructor.
 
@@ -587,11 +602,11 @@ The template parameter `T` of `indirect_value` may be an incomplete type.
 * Throws: Any exception thrown by the selected constructor of `T` or `bad_alloc` if required storage cannot be obtained.
 * Requires `is_same_v<C, default_copy> && is_same_v<D, default_delete>`.
 
-### X.Y.4 Class template `indirect_value` destructor [indirect_value.dtor]
+### X.Z.4 Class template `indirect_value` destructor [indirect_value.dtor]
 <code>~indirect_value();</code>
 * Effects: If `get() == nullptr` there are no effects. If a custom deleter `d` is present then `d(p)` is called and the copier and deleter are destroyed. Otherwise the destructor of the managed object is called.
 
-### X.Y.5 Class template `indirect_value` assignment [indirect_value.assignment]
+### X.Z.5 Class template `indirect_value` assignment [indirect_value.assignment]
 <code>indirect_value& operator=(const indirect_value& p);</code>
 * Constraints: `is_copy_assignable<T>`
 * Effects: `*this` owns a copy of the resource managed by `p`. If `p` has a custom copier and deleter then the copy is created by the copier in `p`, and the copier and deleter of `*this` are copied from those in `p`. Otherwise, the resource managed by `*this` is initialised by the copy constructor of the resource managed by `p`.
@@ -604,12 +619,12 @@ The template parameter `T` of `indirect_value` may be an incomplete type.
 * Returns: `*this`.
 * Postconditions: `*this` contains the old value of `p`. `p` is empty.
 
-### X.Y.6 Class template `indirect_value` modifiers [indirect_value.modifiers]
+### X.Z.6 Class template `indirect_value` modifiers [indirect_value.modifiers]
 <code>void swap(indirect_value<T>& p) noexcept;</code>
 * Effects: Exchanges the contents of `p` and `*this`.
 * Remarks: The method shall work with incomplete pointer type for `T`.
 
-### X.Y.7 Class template `indirect_value` observers [indirect_value.observers]
+### X.Z.7 Class template `indirect_value` observers [indirect_value.observers]
 ```
 T& operator*();
 const T& operator*() const;

--- a/indirect_value.h
+++ b/indirect_value.h
@@ -141,11 +141,11 @@ class ISOCPP_P1950_EMPTY_BASES indirect_value
   template <class U, class = std::enable_if_t<std::is_same_v<T, U> &&
       std::is_default_constructible_v<D> &&
       not std::is_pointer_v<D>>>
-  indirect_value(U* u, C c) noexcept
+  explicit indirect_value(U* u, C c) noexcept
       : copy_base(std::move(c)), delete_base(D{}), ptr_(u) {}
 
   template <class U, class = std::enable_if_t<std::is_same_v<T, U>>>
-  indirect_value(U* u, C c, D d) noexcept
+  explicit indirect_value(U* u, C c, D d) noexcept
       : copy_base(std::move(c)), delete_base(std::move(d)), ptr_(u) {}
 
   indirect_value(const indirect_value& i)

--- a/indirect_value_test.cpp
+++ b/indirect_value_test.cpp
@@ -336,10 +336,10 @@ TEST_CASE("Swap overload for indirect_value", "[swap.primitive]") {
 
     constexpr int a_value = 5;
     constexpr int b_value = 10;
-    indirect_value<int, decltype(+default_copy_lambda_a)> a{
-        new int(a_value), default_copy_lambda_a};
-    indirect_value<int, decltype(+default_copy_lambda_b)> b{
-        new int(b_value), default_copy_lambda_b};
+    indirect_value<int, decltype(+default_copy_lambda_a),
+      std::default_delete<int>> a{new int(a_value), default_copy_lambda_a};
+    indirect_value<int, decltype(+default_copy_lambda_b),
+      std::default_delete<int>> b{new int(b_value), default_copy_lambda_b};
 
     THEN(
         "Confirm sized base class is used and its size requirements meet our "
@@ -510,6 +510,7 @@ TEST_CASE("Calling value on an enganged indirect_value will not throw",
 TEST_CASE("get_copier returns modifiable lvalue reference", "[TODO]") {
   GIVEN("An lvalue of indirect_value with a modifiable copier") {
     struct Copier {
+      using deleter_type = std::default_delete<int>;
       std::string name;
       int* operator()(int x) const {
         REQUIRE(name == "Modified");
@@ -1000,6 +1001,10 @@ struct CopierWithCallback {
     callback();
     return new T(t);
   }
+};
+template<>
+struct isocpp_p1950::copier_traits<CopierWithCallback> {
+  using deleter_type = std::default_delete<int>;
 };
 
 TEST_CASE("Use source copier when copying", "[TODO]") {


### PR DESCRIPTION
If the user supplies a custom copier or specializes `default_copy` (as per [namespace.std]/2) it is likely that `std::default_delete` is no longer appropriate, so they should be required to also supply a custom deleter or explicitly nominate `std::default_delete` as the corresponding deleter.  Add a class template `copier_traits<C>` with member type alias `deleter_type` computed as follows: `typename C::deleter_type` if valid, otherwise, if `C` is a function pointer type, the corresponding deleter function pointer type, otherwise SFINAE-friendly error.  Add type alias `deleter_type = default_delete<T>` to `default_copy<T>`, so that `copier_traits<default_copy<T>>::deleter_type` is `default_delete<T>` (if `default_copy<T>` has not been specialized).

For a custom copier (or specialization of `default_copy`) the user can either supply type alias `deleter_type` in-class or specialize `copier_traits`; demonstrate this in tests.

Split up the constructors and add constraints s.t. pointer copier and deleter are not default-constructed to `nullptr` (`std::unique_ptr` already has this protection).

Update documentation.